### PR TITLE
Add checking for negative weights

### DIFF
--- a/ketama_test.go
+++ b/ketama_test.go
@@ -69,3 +69,29 @@ func TestSegfault(t *testing.T) {
 	}
 
 }
+
+func TestAcceptableWeights(t *testing.T) {
+	var err error
+	var c *Continuum
+
+	_, err = New([]Bucket{{"foo", 1}})
+	if err != nil {
+		t.Errorf("Weight of 1 must be supported.")
+	}
+
+	c, err = New([]Bucket{{"foo", 0}})
+	if err != nil {
+		t.Errorf("Weight of 0 must be supported.")
+	}
+	if len(c.ring) == 0 {
+		t.Errorf("Weight of 0 must be considered to be 1.")
+	}
+
+	_, err = New([]Bucket{{"foo", -1}})
+	if err == nil {
+		t.Errorf("Weight < 0 must be rejected.")
+	}
+	if err != ErrNegativeWeight {
+		t.Errorf("Wrong error returned.")
+	}
+}


### PR DESCRIPTION
This commit adjusts behaviour of New in two ways:

1. Negative weights are rejected by returning and error. Negative
   weights does not make any sense and passing them in is likely just a
   bug in the caller code.

2. Treat weight of 0 the same as 1. Libmemcached does the same and it
   will be nice to have this compatibility.